### PR TITLE
fix: use the right netstat path on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 const util = require('util');
+const which = require('which');
 const exec = util.promisify(require('child_process').exec);
 
 function command(port) {
+  const winNetStat = which.sync('netstat');
   const win = {
-    exe: '\\windows\\system32\\netstat.exe',
+    exe: winNetStat,
     arg: [`-a -n -o ^| findstr :${port}`],
-    cmd: `\\windows\\system32\\netstat.exe -a -n -o | findstr.exe :${port}`,
+    cmd: `${winNetStat} -a -n -o | findstr.exe :${port}`,
   };
 
   const dar = {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "udp",
     "activity"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "which": "^1.3.1"
+  },
   "devDependencies": {
     "eslint": "^5.3.0",
     "eslint-config-airbnb": "^17.1.0",


### PR DESCRIPTION
The program using this package can be in any of the drives on windows machine. The package expected the user of this package to be in C: and did not include the drive path in command. Update the command to use `which`, to compute the right path for netstat command